### PR TITLE
Nico review

### DIFF
--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -12,28 +12,20 @@ weight: 30
 This page provides a real world example of how to configure Redis using a ConfigMap and builds upon the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
 
 
-
 ## {{% heading "objectives" %}}
-
 
 * Create a ConfigMap with Redis configuration values
 * Create a Redis Pod that mounts and uses the created ConfigMap
 * Verify that the configuration was correctly applied.
 
-
-
 ## {{% heading "prerequisites" %}}
-
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
 * The example shown on this page works with `kubectl` 1.14 and above.
 * Understand [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/).
 
-
-
 <!-- lessoncontent -->
-
 
 ## Real World Example: Configuring Redis using a ConfigMap
 

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -145,7 +145,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     2) "noeviction"
     ```
 
-9.  Add the highlighted configuration values to the `example-redis-config.yaml` ConfigMap:
+9. Add the highlighted configuration values to the `example-redis-config.yaml` ConfigMap:
 
     **Note**: Don't forget to include the `|` operator.
 

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -9,13 +9,13 @@ weight: 30
 
 <!-- overview -->
 
-This page provides a real world example of how to configure [Redis](https://redis.io/docs/latest/) using a [ConfigMap](../../concepts/configuration/configmap.md) and builds on the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) tutorial. 
+This tutorial provides a real-world example of how to configure [Redis](https://redis.io/docs/latest/) using a [ConfigMap](../../concepts/configuration/configmap.md) and builds on the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
 
 
 ## {{% heading "objectives" %}}
 
-* Create a ConfigMap with Redis configuration values
-* Create a Redis Pod that mounts and uses the created ConfigMap
+* Create a ConfigMap with Redis configuration values.
+* Create a Redis Pod that mounts and uses the created ConfigMap.
 * Verify that the configuration was correctly applied.
 
 ## {{% heading "prerequisites" %}}

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -21,7 +21,7 @@ This tutorial provides a real-world example of how to configure [Redis](https://
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
-* The example shown on this page works with `kubectl` 1.14 and above.
+* The example on this page works with `kubectl` 1.14 and above.
 * Understand [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/).
 
 <!-- lessoncontent -->

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -9,7 +9,7 @@ weight: 30
 
 <!-- overview -->
 
-This tutorial provides a real-world example of how to configure [Redis](https://redis.io/docs/latest/) using a [ConfigMap](../../concepts/configuration/configmap.md) and builds on the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
+This tutorial provides a real-world example of how to configure [Redis](https://redis.io/docs/latest/) using a [ConfigMap](../../concepts/configuration/configmap.md) and builds on the [Configure a Pod to Use a ConfigMap](../../tasks/configure-pod-container/configure-pod-configmap.md) task. 
 
 ## {{% heading "objectives" %}}
 
@@ -119,7 +119,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
 
 7. Check `maxmemory`:
 
-    **Note**: Remember to not include the `127.0.0.1:6379>` part of the prompt when copying and pasting the command to run.
+    **Note**: Don't include the `127.0.0.1:6379>` part of the prompt when copying and pasting the command to run.
 
     ```shell
     127.0.0.1:6379> CONFIG GET maxmemory

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -224,7 +224,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     127.0.0.1:6379> CONFIG GET maxmemory
     ```
 
-    It should now return the updated value of 2097152:
+    It should now return the updated value of `2097152`:
 
     ```shell
     1) "maxmemory"
@@ -237,7 +237,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     127.0.0.1:6379> CONFIG GET maxmemory-policy
     ```
 
-    It now reflects the desired value of `allkeys-lru`:
+    It should now reflect the desired value of `allkeys-lru`:
 
     ```shell
     1) "maxmemory-policy"

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -22,7 +22,7 @@ This tutorial provides a real-world example of how to configure [Redis](https://
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
 * The example on this page works with `kubectl` 1.14 and above.
-* Understand [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/).
+* Understand [Configure a Pod to Use a ConfigMap](../../tasks/configure-pod-container/configure-pod-configmap.md).
 
 <!-- lessoncontent -->
 
@@ -52,7 +52,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
     ```
 
-3. Run this command to examine the contents of the Redis pod manifest:
+3. Run this command to examine the contents of the Redis pod manifest YAML file:
 
     ```
     curl https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
@@ -155,7 +155,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
 
     Exit the `redis-cli` interactive session:
 
-    ```
+    ```shell
     EXIT
     ```
 
@@ -193,7 +193,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     kubectl exec -it redis -- redis-cli
     ```
 
-    Then Repeat steps 7 and 8 to check `maxmemory` and `maxmemory-policy`.
+    Repeat steps 7 and 8 to check `maxmemory` and `maxmemory-policy`.
   
     The configuration values should *not* have changed because the Pod needs to be restarted to grab updated values from associated ConfigMaps. 
     
@@ -201,7 +201,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
 
     Exit the `redis-cli` interactive session:
 
-    ```
+    ```shell
     EXIT
     ```
 
@@ -248,7 +248,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
 
     Exit the `redis-cli` interactive session:
 
-    ```
+    ```shell
     EXIT
     ```
 

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -68,13 +68,13 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
 
     {{% code_sample file="pods/config/redis-pod.yaml" %}}
 
-4. Examine the created objects:
+4. Run this command to examine the created objects:
 
     ```shell
     kubectl get pod/redis configmap/example-redis-config 
     ```
 
-    You should see the following output:
+    You should see this output:
 
     ```
     NAME        READY   STATUS    RESTARTS   AGE
@@ -109,7 +109,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     kubectl exec -it redis -- redis-cli
     ```
 
-    If successful, the command drops you into the `redis-cli` promt:
+    If successful, the command drops you into the `redis-cli` prompt:
 
     ```shell
     127.0.0.1:6379>
@@ -119,7 +119,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
 
 7. Check `maxmemory`:
 
-    **Note**: Don't include the `127.0.0.1:6379>` part of the prompt when copying and pasting the command to run.
+    **Note**: Don't include the `127.0.0.1:6379>` part of the code block when copying and pasting the commands.
 
     ```shell
     127.0.0.1:6379> CONFIG GET maxmemory
@@ -145,7 +145,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     2) "noeviction"
     ```
 
-9.  Add the highlighted configuration values to the `example-redis-config` ConfigMap:
+9.  Add the highlighted configuration values to the `example-redis-config.yaml` ConfigMap:
 
     **Note**: Don't forget to include the `|` operator.
 
@@ -187,17 +187,17 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     maxmemory-policy allkeys-lru
     ```
 
-12. Check the Redis Pod again using `redis-cli` via `kubectl exec` to see if the configuration was applied:
+12. Use `kubectl exec` to enter the pod and run the `redis-cli` tool again to see if the configuration was applied:
 
     ```shell
     kubectl exec -it redis -- redis-cli
     ```
 
-13. Repeat steps 7 and 8 to check `maxmemory` and `maxmemory-policy`.
+    Then Repeat steps 7 and 8 to check `maxmemory` and `maxmemory-policy`.
   
-    The configuration values haven't changed because the Pod needs to be restarted to grab updated values from associated ConfigMaps. 
+    The configuration values should *not* have changed because the Pod needs to be restarted to grab updated values from associated ConfigMaps. 
     
-14. Delete and recreate the Pod:
+13. Delete and recreate the Pod:
 
     Exit the `redis-cli` interactive session:
 
@@ -212,13 +212,13 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
     ```
 
-15. Re-enter the `redis-cli` interactive session to check the configuration values one last time:
+14. Re-enter the `redis-cli` interactive session to check the configuration values one last time:
 
     ```shell
     kubectl exec -it redis -- redis-cli
     ```
 
-16. Check `maxmemory`:
+15. Check `maxmemory`:
 
     ```shell
     127.0.0.1:6379> CONFIG GET maxmemory
@@ -231,7 +231,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     2) "2097152"
     ```
 
-17. Check that `maxmemory-policy` has also been updated:
+16. Check that `maxmemory-policy` has also been updated:
 
     ```shell
     127.0.0.1:6379> CONFIG GET maxmemory-policy
@@ -244,7 +244,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     2) "allkeys-lru"
     ```
 
-18. Clean up your work by deleting the created resources:
+17. Clean up your work by deleting the created resources:
 
     Exit the `redis-cli` interactive session:
 

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -11,7 +11,6 @@ weight: 30
 
 This tutorial provides a real-world example of how to configure [Redis](https://redis.io/docs/latest/) using a [ConfigMap](../../concepts/configuration/configmap.md) and builds on the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
 
-
 ## {{% heading "objectives" %}}
 
 * Create a ConfigMap with Redis configuration values.

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -2,7 +2,7 @@
 reviewers:
 - eparis
 - pmorie
-title: Configuring Redis using a ConfigMap
+title: Configure Redis using a ConfigMap
 content_type: tutorial
 weight: 30
 ---

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -26,9 +26,9 @@ This tutorial provides a real-world example of how to configure [Redis](https://
 
 <!-- lessoncontent -->
 
-## Real World Example: Configuring Redis using a ConfigMap
+## Real world example: Configure Redis using a ConfigMap
 
-Follow the steps below to configure a Redis cache using data stored in a ConfigMap.
+Follow these steps to configure a Redis cache using data stored in a ConfigMap:
 
 1. Create a ConfigMap with an empty configuration block:
 

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -30,7 +30,7 @@ This tutorial provides a real-world example of how to configure [Redis](https://
 
 Follow these steps to configure a Redis cache using data stored in a ConfigMap:
 
-1. Create a ConfigMap with an empty configuration block:
+1. Run this command to create a ConfigMap with an empty configuration block:
 
     ```shell
     cat <<EOF >./example-redis-config.yaml
@@ -43,14 +43,22 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     EOF
     ```
 
-2. Apply the ConfigMap created above, along with a Redis pod manifest:
+    A file named `example-redis-config.yaml` is created in your current directory.
+
+2. Run these commands to apply the ConfigMap created above, along with a Redis pod manifest:
 
     ```shell
     kubectl apply -f example-redis-config.yaml
     kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
     ```
 
-3. Examine the contents of the Redis pod manifest and note the following:
+3. Run this command to examine the contents of the Redis pod manifest:
+
+    ```
+    curl https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
+    ```
+
+    Check for these:
     
     * A volume named `config` is created by `spec.volumes[1]`.
     * The `key` and `path` under `spec.volumes[1].configMap.items[0]` exposes the `redis-config` key from the `example-redis-config` ConfigMap as a file named `redis.conf` on the `config` volume.
@@ -76,7 +84,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     configmap/example-redis-config   1      14s
     ```
 
-    Recall that we left `redis-config` key in the `example-redis-config` ConfigMap blank:
+5. Run this command to verify that the `redis-config` key in the `example-redis-config` ConfigMap is still blank:
 
     ```shell
     kubectl describe configmap/example-redis-config
@@ -95,13 +103,21 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     redis-config:
     ```
 
-5. Use `kubectl exec` to enter the pod and run the `redis-cli` tool to check the current configuration:
+6. Use `kubectl exec` to enter the pod and run the `redis-cli` tool to check the current configuration:
 
     ```shell
     kubectl exec -it redis -- redis-cli
     ```
 
-6. Check `maxmemory`:
+    If successful, the command drops you into the `redis-cli` promt:
+
+    ```shell
+    127.0.0.1:6379>
+    ```
+
+    This verifies that the Redis Pod is running and accessible.
+
+7. Check `maxmemory`:
 
     ```shell
     127.0.0.1:6379> CONFIG GET maxmemory
@@ -114,30 +130,30 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     2) "0"
     ```
 
-7. Similarly, check `maxmemory-policy`:
+8. Similarly, check `maxmemory-policy`:
 
     ```shell
     127.0.0.1:6379> CONFIG GET maxmemory-policy
     ```
 
-    Which should also yield its default value of `noeviction`:
+    This should also yield its default value of `noeviction`:
 
     ```shell
     1) "maxmemory-policy"
     2) "noeviction"
     ```
 
-8. Add configuration values to the `example-redis-config` ConfigMap:
+9. Add configuration values to the `example-redis-config` ConfigMap:
 
     {{% code_sample file="pods/config/example-redis-config.yaml" %}}
 
-9. Apply the updated ConfigMap:
+10.  Apply the updated ConfigMap:
 
     ```shell
     kubectl apply -f example-redis-config.yaml
     ```
 
-10. Confirm that the ConfigMap was updated:
+11. Confirm that the ConfigMap was updated:
 
     ```shell
     kubectl describe configmap/example-redis-config
@@ -159,13 +175,13 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     maxmemory-policy allkeys-lru
     ```
 
-11. Check the Redis Pod again using `redis-cli` via `kubectl exec` to see if the configuration was applied:
+12. Check the Redis Pod again using `redis-cli` via `kubectl exec` to see if the configuration was applied:
 
     ```shell
     kubectl exec -it redis -- redis-cli
     ```
 
-12. Check `maxmemory`:
+13. Check `maxmemory`:
    
     ```shell
     127.0.0.1:6379> CONFIG GET maxmemory
@@ -178,7 +194,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     2) "0"
     ```
 
-13. Similarly, check `maxmemory-policy` which remains at the `noeviction` default setting:
+14. Similarly, check `maxmemory-policy` which remains at the `noeviction` default setting:
 
     ```shell
     127.0.0.1:6379> CONFIG GET maxmemory-policy
@@ -193,20 +209,20 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
 
     The configuration values have not changed because the Pod needs to be restarted to grab updated values from associated ConfigMaps. 
     
-14. Delete and recreate the Pod:
+15. Delete and recreate the Pod:
 
     ```shell
     kubectl delete pod redis
     kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
     ```
 
-15. Re-check the configuration values one last time:
+16. Re-check the configuration values one last time:
 
     ```shell
     kubectl exec -it redis -- redis-cli
     ```
 
-16. Check `maxmemory`:
+17. Check `maxmemory`:
 
     ```shell
     127.0.0.1:6379> CONFIG GET maxmemory
@@ -219,7 +235,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     2) "2097152"
     ```
 
-17. Similarly, check that `maxmemory-policy` has also been updated:
+18. Similarly, check that `maxmemory-policy` has also been updated:
 
     ```shell
     127.0.0.1:6379> CONFIG GET maxmemory-policy
@@ -232,7 +248,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     2) "allkeys-lru"
     ```
 
-18. Clean up your work by deleting the created resources:
+19. Clean up your work by deleting the created resources:
 
     ```shell
     kubectl delete pod/redis configmap/example-redis-config

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -9,7 +9,7 @@ weight: 30
 
 <!-- overview -->
 
-This tutorial provides a real-world example of how to configure [Redis](https://redis.io/docs/latest/) using a [ConfigMap](../../concepts/configuration/configmap.md) and builds on the [Configure a Pod to Use a ConfigMap](../../tasks/configure-pod-container/configure-pod-configmap.md) task. 
+This tutorial provides a real-world example of how to configure [Redis](https://redis.io/docs/latest/) using a [ConfigMap](../../concepts/configuration/configmap.md).
 
 ## {{% heading "objectives" %}}
 
@@ -22,7 +22,7 @@ This tutorial provides a real-world example of how to configure [Redis](https://
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
 * The example on this page works with `kubectl` 1.14 and above.
-* Understand [Configure a Pod to Use a ConfigMap](../../tasks/configure-pod-container/configure-pod-configmap.md).
+* Ensure you understand how to [Configure a Pod to Use a ConfigMap](../../tasks/configure-pod-container/configure-pod-configmap.md).
 
 <!-- lessoncontent -->
 

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -9,7 +9,7 @@ weight: 30
 
 <!-- overview -->
 
-This page provides a real world example of how to configure Redis using a ConfigMap and builds upon the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
+This page provides a real world example of how to configure [Redis](https://redis.io/docs/latest/) using a [ConfigMap](../../concepts/configuration/configmap.md) and builds on the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) tutorial. 
 
 
 ## {{% heading "objectives" %}}

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -7,8 +7,6 @@ content_type: tutorial
 weight: 30
 ---
 
-<!-- overview -->
-
 This tutorial provides a real-world example of how to configure [Redis](https://redis.io/docs/latest/) using a [ConfigMap](../../concepts/configuration/configmap.md).
 
 ## {{% heading "objectives" %}}
@@ -23,8 +21,6 @@ This tutorial provides a real-world example of how to configure [Redis](https://
 
 * The example on this page works with `kubectl` 1.14 and above.
 * Ensure you understand how to [Configure a Pod to Use a ConfigMap](../../tasks/configure-pod-container/configure-pod-configmap.md).
-
-<!-- lessoncontent -->
 
 ## Real world example: Configure Redis using a ConfigMap
 

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -147,6 +147,8 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
 
 9.  Add the highlighted configuration values to the `example-redis-config` ConfigMap:
 
+    **Note**: Don't forget to include the `|` operator.
+
     {{% code_sample file="pods/config/example-redis-config.yaml" %}}
 
 10. Apply the updated ConfigMap:
@@ -191,35 +193,11 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     kubectl exec -it redis -- redis-cli
     ```
 
-13. Check `maxmemory`:
-   
-    ```shell
-    127.0.0.1:6379> CONFIG GET maxmemory
-    ```
-
-    It remains at the default value of 0:
-
-    ```shell
-    1) "maxmemory"
-    2) "0"
-    ```
-
-14. Check `maxmemory-policy` which remains at the `noeviction` default setting:
-
-    ```shell
-    127.0.0.1:6379> CONFIG GET maxmemory-policy
-    ```
-
-    Returns:
-
-    ```shell
-    1) "maxmemory-policy"
-    2) "noeviction"
-    ```
-
-    The configuration values have not changed because the Pod needs to be restarted to grab updated values from associated ConfigMaps. 
+13. Repeat steps 7 and 8 to check `maxmemory` and `maxmemory-policy`.
+  
+    The configuration values haven't changed because the Pod needs to be restarted to grab updated values from associated ConfigMaps. 
     
-15. Delete and recreate the Pod:
+14. Delete and recreate the Pod:
 
     Exit the `redis-cli` interactive session:
 
@@ -234,13 +212,13 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
     ```
 
-16. Re-check the configuration values one last time:
+15. Re-enter the `redis-cli` interactive session to check the configuration values one last time:
 
     ```shell
     kubectl exec -it redis -- redis-cli
     ```
 
-17. Check `maxmemory`:
+16. Check `maxmemory`:
 
     ```shell
     127.0.0.1:6379> CONFIG GET maxmemory
@@ -253,7 +231,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     2) "2097152"
     ```
 
-18. Similarly, check that `maxmemory-policy` has also been updated:
+17. Check that `maxmemory-policy` has also been updated:
 
     ```shell
     127.0.0.1:6379> CONFIG GET maxmemory-policy
@@ -266,7 +244,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     2) "allkeys-lru"
     ```
 
-19. Clean up your work by deleting the created resources:
+18. Clean up your work by deleting the created resources:
 
     Exit the `redis-cli` interactive session:
 

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -260,5 +260,5 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
 
 ## {{% heading "whatsnext" %}}
 
-* Learn more about [ConfigMaps](/docs/tasks/configure-pod-container/configure-pod-configmap/).
-* Follow an example of [Updating configuration via a ConfigMap](/docs/tutorials/configuration/updating-configuration-via-a-configmap/).
+* Learn more about [ConfigMaps](../../tasks/configure-pod-container/configure-pod-configmap.md).
+* Follow an example of [Updating configuration via a ConfigMap](updating-configuration-via-a-configmap.md).

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -119,6 +119,8 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
 
 7. Check `maxmemory`:
 
+    **Note**: Remember to not include the `127.0.0.1:6379>` part of the prompt when copying and pasting the command to run.
+
     ```shell
     127.0.0.1:6379> CONFIG GET maxmemory
     ```
@@ -130,7 +132,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     2) "0"
     ```
 
-8. Similarly, check `maxmemory-policy`:
+8. Check `maxmemory-policy`:
 
     ```shell
     127.0.0.1:6379> CONFIG GET maxmemory-policy
@@ -143,11 +145,19 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     2) "noeviction"
     ```
 
-9. Add configuration values to the `example-redis-config` ConfigMap:
+9.  Add the highlighted configuration values to the `example-redis-config` ConfigMap:
 
     {{% code_sample file="pods/config/example-redis-config.yaml" %}}
 
-10.  Apply the updated ConfigMap:
+10. Apply the updated ConfigMap:
+
+    Exit the `redis-cli` interactive session:
+
+    ```
+    EXIT
+    ```
+
+    Then run:
 
     ```shell
     kubectl apply -f example-redis-config.yaml
@@ -194,7 +204,7 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     2) "0"
     ```
 
-14. Similarly, check `maxmemory-policy` which remains at the `noeviction` default setting:
+14. Check `maxmemory-policy` which remains at the `noeviction` default setting:
 
     ```shell
     127.0.0.1:6379> CONFIG GET maxmemory-policy
@@ -210,6 +220,14 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     The configuration values have not changed because the Pod needs to be restarted to grab updated values from associated ConfigMaps. 
     
 15. Delete and recreate the Pod:
+
+    Exit the `redis-cli` interactive session:
+
+    ```
+    EXIT
+    ```
+
+    Then run:
 
     ```shell
     kubectl delete pod redis
@@ -249,6 +267,14 @@ Follow these steps to configure a Redis cache using data stored in a ConfigMap:
     ```
 
 19. Clean up your work by deleting the created resources:
+
+    Exit the `redis-cli` interactive session:
+
+    ```
+    EXIT
+    ```
+
+    Then run:
 
     ```shell
     kubectl delete pod/redis configmap/example-redis-config

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -30,217 +30,215 @@ This tutorial provides a real-world example of how to configure [Redis](https://
 
 Follow the steps below to configure a Redis cache using data stored in a ConfigMap.
 
-First create a ConfigMap with an empty configuration block:
+1. Create a ConfigMap with an empty configuration block:
 
-```shell
-cat <<EOF >./example-redis-config.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: example-redis-config
-data:
-  redis-config: ""
-EOF
-```
+    ```shell
+    cat <<EOF >./example-redis-config.yaml
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: example-redis-config
+    data:
+      redis-config: ""
+    EOF
+    ```
 
-Apply the ConfigMap created above, along with a Redis pod manifest:
+2. Apply the ConfigMap created above, along with a Redis pod manifest:
 
-```shell
-kubectl apply -f example-redis-config.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
-```
+    ```shell
+    kubectl apply -f example-redis-config.yaml
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
+    ```
 
-Examine the contents of the Redis pod manifest and note the following:
+3. Examine the contents of the Redis pod manifest and note the following:
+    
+    * A volume named `config` is created by `spec.volumes[1]`.
+    * The `key` and `path` under `spec.volumes[1].configMap.items[0]` exposes the `redis-config` key from the `example-redis-config` ConfigMap as a file named `redis.conf` on the `config` volume.
+    * The `config` volume is then mounted at `/redis-master` by `spec.containers[0].volumeMounts[1]`.
 
-* A volume named `config` is created by `spec.volumes[1]`
-* The `key` and `path` under `spec.volumes[1].configMap.items[0]` exposes the `redis-config` key from the 
-  `example-redis-config` ConfigMap as a file named `redis.conf` on the `config` volume.
-* The `config` volume is then mounted at `/redis-master` by `spec.containers[0].volumeMounts[1]`.
+    This has the net effect of exposing the data in `data.redis-config` from the `example-redis-config` ConfigMap above as `/redis-master/redis.conf` inside the Pod:
 
-This has the net effect of exposing the data in `data.redis-config` from the `example-redis-config`
-ConfigMap above as `/redis-master/redis.conf` inside the Pod.
+    {{% code_sample file="pods/config/redis-pod.yaml" %}}
 
-{{% code_sample file="pods/config/redis-pod.yaml" %}}
+4. Examine the created objects:
 
-Examine the created objects:
+    ```shell
+    kubectl get pod/redis configmap/example-redis-config 
+    ```
 
-```shell
-kubectl get pod/redis configmap/example-redis-config 
-```
+    You should see the following output:
 
-You should see the following output:
+    ```
+    NAME        READY   STATUS    RESTARTS   AGE
+    pod/redis   1/1     Running   0          8s
 
-```
-NAME        READY   STATUS    RESTARTS   AGE
-pod/redis   1/1     Running   0          8s
+    NAME                             DATA   AGE
+    configmap/example-redis-config   1      14s
+    ```
 
-NAME                             DATA   AGE
-configmap/example-redis-config   1      14s
-```
+    Recall that we left `redis-config` key in the `example-redis-config` ConfigMap blank:
 
-Recall that we left `redis-config` key in the `example-redis-config` ConfigMap blank:
+    ```shell
+    kubectl describe configmap/example-redis-config
+    ```
 
-```shell
-kubectl describe configmap/example-redis-config
-```
+    You should see an empty `redis-config` key:
 
-You should see an empty `redis-config` key:
+    ```shell
+    Name:         example-redis-config
+    Namespace:    default
+    Labels:       <none>
+    Annotations:  <none>
 
-```shell
-Name:         example-redis-config
-Namespace:    default
-Labels:       <none>
-Annotations:  <none>
+    Data
+    ====
+    redis-config:
+    ```
 
-Data
-====
-redis-config:
-```
+5. Use `kubectl exec` to enter the pod and run the `redis-cli` tool to check the current configuration:
 
-Use `kubectl exec` to enter the pod and run the `redis-cli` tool to check the current configuration:
+    ```shell
+    kubectl exec -it redis -- redis-cli
+    ```
 
-```shell
-kubectl exec -it redis -- redis-cli
-```
+6. Check `maxmemory`:
 
-Check `maxmemory`:
+    ```shell
+    127.0.0.1:6379> CONFIG GET maxmemory
+    ```
 
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory
-```
+    It should show the default value of 0:
 
-It should show the default value of 0:
+    ```shell
+    1) "maxmemory"
+    2) "0"
+    ```
 
-```shell
-1) "maxmemory"
-2) "0"
-```
+7. Similarly, check `maxmemory-policy`:
 
-Similarly, check `maxmemory-policy`:
+    ```shell
+    127.0.0.1:6379> CONFIG GET maxmemory-policy
+    ```
 
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory-policy
-```
+    Which should also yield its default value of `noeviction`:
 
-Which should also yield its default value of `noeviction`:
+    ```shell
+    1) "maxmemory-policy"
+    2) "noeviction"
+    ```
 
-```shell
-1) "maxmemory-policy"
-2) "noeviction"
-```
+8. Add configuration values to the `example-redis-config` ConfigMap:
 
-Now let's add some configuration values to the `example-redis-config` ConfigMap:
+    {{% code_sample file="pods/config/example-redis-config.yaml" %}}
 
-{{% code_sample file="pods/config/example-redis-config.yaml" %}}
+9. Apply the updated ConfigMap:
 
-Apply the updated ConfigMap:
+    ```shell
+    kubectl apply -f example-redis-config.yaml
+    ```
 
-```shell
-kubectl apply -f example-redis-config.yaml
-```
+10. Confirm that the ConfigMap was updated:
 
-Confirm that the ConfigMap was updated:
+    ```shell
+    kubectl describe configmap/example-redis-config
+    ```
 
-```shell
-kubectl describe configmap/example-redis-config
-```
+    You should see the configuration values we just added:
 
-You should see the configuration values we just added:
+    ```shell
+    Name:         example-redis-config
+    Namespace:    default
+    Labels:       <none>
+    Annotations:  <none>
 
-```shell
-Name:         example-redis-config
-Namespace:    default
-Labels:       <none>
-Annotations:  <none>
+    Data
+    ====
+    redis-config:
+    ----
+    maxmemory 2mb
+    maxmemory-policy allkeys-lru
+    ```
 
-Data
-====
-redis-config:
-----
-maxmemory 2mb
-maxmemory-policy allkeys-lru
-```
+11. Check the Redis Pod again using `redis-cli` via `kubectl exec` to see if the configuration was applied:
 
-Check the Redis Pod again using `redis-cli` via `kubectl exec` to see if the configuration was applied:
+    ```shell
+    kubectl exec -it redis -- redis-cli
+    ```
 
-```shell
-kubectl exec -it redis -- redis-cli
-```
+12. Check `maxmemory`:
+   
+    ```shell
+    127.0.0.1:6379> CONFIG GET maxmemory
+    ```
 
-Check `maxmemory`:
+    It remains at the default value of 0:
 
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory
-```
+    ```shell
+    1) "maxmemory"
+    2) "0"
+    ```
 
-It remains at the default value of 0:
+13. Similarly, check `maxmemory-policy` which remains at the `noeviction` default setting:
 
-```shell
-1) "maxmemory"
-2) "0"
-```
+    ```shell
+    127.0.0.1:6379> CONFIG GET maxmemory-policy
+    ```
 
-Similarly, `maxmemory-policy` remains at the `noeviction` default setting:
+    Returns:
 
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory-policy
-```
+    ```shell
+    1) "maxmemory-policy"
+    2) "noeviction"
+    ```
 
-Returns:
+    The configuration values have not changed because the Pod needs to be restarted to grab updated values from associated ConfigMaps. 
+    
+14. Delete and recreate the Pod:
 
-```shell
-1) "maxmemory-policy"
-2) "noeviction"
-```
+    ```shell
+    kubectl delete pod redis
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
+    ```
 
-The configuration values have not changed because the Pod needs to be restarted to grab updated
-values from associated ConfigMaps. Let's delete and recreate the Pod:
+15. Re-check the configuration values one last time:
 
-```shell
-kubectl delete pod redis
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
-```
+    ```shell
+    kubectl exec -it redis -- redis-cli
+    ```
 
-Now re-check the configuration values one last time:
+16. Check `maxmemory`:
 
-```shell
-kubectl exec -it redis -- redis-cli
-```
+    ```shell
+    127.0.0.1:6379> CONFIG GET maxmemory
+    ```
 
-Check `maxmemory`:
+    It should now return the updated value of 2097152:
 
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory
-```
+    ```shell
+    1) "maxmemory"
+    2) "2097152"
+    ```
 
-It should now return the updated value of 2097152:
+17. Similarly, check that `maxmemory-policy` has also been updated:
 
-```shell
-1) "maxmemory"
-2) "2097152"
-```
+    ```shell
+    127.0.0.1:6379> CONFIG GET maxmemory-policy
+    ```
 
-Similarly, `maxmemory-policy` has also been updated:
+    It now reflects the desired value of `allkeys-lru`:
 
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory-policy
-```
+    ```shell
+    1) "maxmemory-policy"
+    2) "allkeys-lru"
+    ```
 
-It now reflects the desired value of `allkeys-lru`:
+18. Clean up your work by deleting the created resources:
 
-```shell
-1) "maxmemory-policy"
-2) "allkeys-lru"
-```
-
-Clean up your work by deleting the created resources:
-
-```shell
-kubectl delete pod/redis configmap/example-redis-config
-```
+    ```shell
+    kubectl delete pod/redis configmap/example-redis-config
+    ```
 
 ## {{% heading "whatsnext" %}}
-
 
 * Learn more about [ConfigMaps](/docs/tasks/configure-pod-container/configure-pod-configmap/).
 * Follow an example of [Updating configuration via a ConfigMap](/docs/tutorials/configuration/updating-configuration-via-a-configmap/).

--- a/content/en/includes/task-tutorial-prereqs.md
+++ b/content/en/includes/task-tutorial-prereqs.md
@@ -1,6 +1,9 @@
-You need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your cluster. It is recommended to run this tutorial on a cluster with at least two nodes that are not acting as control plane hosts. If you do not already have a
-cluster, you can create one by using [minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/)
-or you can use one of these Kubernetes playgrounds:
+Before you begin, you need:
+
+* A Kubernetes cluster.
+* The [kubectl command-line tool](/docs/tasks/tools/) installed and configured to communicate with your cluster.
+
+**Note**: It's recommended to run this tutorial on a cluster with at least two worker nodes that are not acting as control plane hosts. Alternatively, you can use a single-node [minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/) or use one of these Kubernetes playgrounds, which support multi-node custers:
 
 * [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [KodeKloud](https://kodekloud.com/public-playgrounds)

--- a/content/en/includes/task-tutorial-prereqs.md
+++ b/content/en/includes/task-tutorial-prereqs.md
@@ -3,7 +3,7 @@ Before you begin, you need:
 * A Kubernetes cluster.
 * The [kubectl command-line tool](../docs/tasks/tools/_index.md) installed and configured to communicate with your cluster.
 
-**Note**: It's recommended to run this tutorial on a cluster with at least two worker nodes that are not acting as control plane hosts. Alternatively, you can use a single-node [minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/) or use one of these Kubernetes playgrounds, which support multi-node custers:
+**Note**: It's recommended to run this tutorial on a cluster with at least two worker nodes that are not acting as control plane hosts. Alternatively, you can use a single-node cluster with [minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/) or use one of these Kubernetes playgrounds, which support multi-node clusters:
 
 * [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [KodeKloud](https://kodekloud.com/public-playgrounds)

--- a/content/en/includes/task-tutorial-prereqs.md
+++ b/content/en/includes/task-tutorial-prereqs.md
@@ -1,7 +1,7 @@
 Before you begin, you need:
 
 * A Kubernetes cluster.
-* The [kubectl command-line tool](/docs/tasks/tools/) installed and configured to communicate with your cluster.
+* The [kubectl command-line tool](../docs/tasks/tools/_index.md) installed and configured to communicate with your cluster.
 
 **Note**: It's recommended to run this tutorial on a cluster with at least two worker nodes that are not acting as control plane hosts. Alternatively, you can use a single-node [minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/) or use one of these Kubernetes playgrounds, which support multi-node custers:
 

--- a/content/en/includes/task-tutorial-prereqs.md
+++ b/content/en/includes/task-tutorial-prereqs.md
@@ -3,7 +3,7 @@ Before you begin, you need:
 * A Kubernetes cluster.
 * The [kubectl command-line tool](../docs/tasks/tools/_index.md) installed and configured to communicate with your cluster.
 
-**Note**: It's recommended to run this tutorial on a cluster with at least two worker nodes that are not acting as control plane hosts. Alternatively, you can use a single-node cluster with [minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/) or use one of these Kubernetes playgrounds, which support multi-node clusters:
+**Note**: It's recommended to run this tutorial on a cluster with at least two worker nodes that are not acting as control plane hosts. If you don't already have a multi-node cluster, you can [create one with minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/) or use one of these Kubernetes playgrounds:
 
 * [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [KodeKloud](https://kodekloud.com/public-playgrounds)

--- a/content/en/includes/task-tutorial-prereqs.md
+++ b/content/en/includes/task-tutorial-prereqs.md
@@ -1,7 +1,5 @@
-You need to have a Kubernetes cluster, and the kubectl command-line tool must
-be configured to communicate with your cluster. It is recommended to run this tutorial on a cluster with at least two nodes that are not acting as control plane hosts. If you do not already have a
-cluster, you can create one by using
-[minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/)
+You need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your cluster. It is recommended to run this tutorial on a cluster with at least two nodes that are not acting as control plane hosts. If you do not already have a
+cluster, you can create one by using [minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/)
 or you can use one of these Kubernetes playgrounds:
 
 * [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -661,7 +661,7 @@ other = "Your Kubernetes server must be version "
 other = "Your Kubernetes server must be at or later than version "
 
 [version_check_tocheck]
-other = "To check the version, enter "
+other = "Check the version by entering "
 
 [version_menu]
 other = "Versions"


### PR DESCRIPTION
This PR updates the [Kubernetes Redis ConfigMap tutorial](https://kubernetes.io/docs/tutorials/configuration/configure-redis-using-configmap/) from their open source docs to improve clarity, structure, and suitability for all skill levels. I used Killercoda to test the steps/commands to ensure precision.

Key change include:

- Restructured tutorial into a clear, numbered list for better readability.
- Added step _results_ and notes to guide users, especially those new to Kubernetes and Redis.
- Improved the prerequisites with suggestions regarding Minikube, Kubernetes Playgrounds, and multi-node clusters.

PDF with further explanation of my edits: [kubernetes-review-project.pdf](https://github.com/user-attachments/files/20829010/kubernetes-review-project.pdf)

